### PR TITLE
fix: package names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,7 +67,7 @@ podTemplate(
                             script: 'git rev-parse --short HEAD'
                     ).trim()
                     def pullRequestVersion = "${currentVersion}+${env.BRANCH_NAME}.${shortGitRev}"
-                    sh(script:"sed -i \'s/version = ${currentVersion}/version = ${pullRequestVersion}/g\' pyhive/__init__.py", label: 'Changing version for PR')
+                    sh(script:"sed -i 's/__version__ = \"${currentVersion}\"/__version__ = \"${pullRequestVersion}\"/g' pyhive/__init__.py", label: 'Changing version for PR')
                     sh(script:"echo PR version: ${pullRequestVersion}", label: 'PR Release candidate version')
                 }
                 sh(script: 'python setup.py sdist --formats=gztar', label: 'Bundling release')

--- a/pyhive/__init__.py
+++ b/pyhive/__init__.py
@@ -2,4 +2,4 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 
 # major, minor, patch (upstream) and preset version
-__version__ = '0.7.0.1'
+__version__ = "0.7.0.1"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[egg_info]
-tag_build = dev
-
 [tool:pytest]
 timeout = 100
 timeout_method = thread


### PR DESCRIPTION
The Jenkinsfile from #2 was generating the same package name for PRs and `master`:

https://pypi.devops.preset.zone/PyHive/pyhive-0.7.0.1.dev0.tar.gz

WIth this PR, the names of the packages are:

https://pypi.devops.preset.zone/PyHive/pyhive-0.7.0.1+pr.3.3f1ccfa.tar.gz (this PR)
https://pypi.devops.preset.zone/PyHive/pyhive-0.7.0.1.tar.gz (from master)